### PR TITLE
Fix gpg signing in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: Publish container
 on:
   push:
     branches: [ main ]
-  pull_request: { }
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It seems that after updating from 1.6 to 3.0.1 of the gpg maven plugin, the deploy workflow no longer finds the gpg private key.

However, the private key, nor the workflow changed. The new version seems to require a different env var for the gpg passphrase. Perhaps a new name helps to re-import the key or invalidate a cache or so. It's not really clear to me.