### PR TITLE
Document connection to Camunda Platform Self-Managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ These Spring Boot properties can be directly used as environment variables.
 Simply pass the file to Docker when you start up the container.
 
 ```shell
-docker run --env-file <path-to-credentials-spring-boot-file> -p 8080:8080 ghcr.io/korthout/zeebe-rest-client:latest
+docker run -p 8080:8080 \
+  --env-file /path-to-credentials-spring-boot-file \
+  ghcr.io/korthout/zeebe-rest-client:latest
 ```
 
 > **Note**


### PR DESCRIPTION
If we want this tool to be easy to get started with, it should clearly instruct how to connect to a Camunda Platform cluster. That also includes how to connect to a self-managed cluster.

This pull requests documents on how to run the Zeebe REST Client to connect it to their own Camunda Platform Self-Managed cluster.