### PR TITLE
fix: GET /jobs

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,2 +1,6 @@
 server:
   port: 8080
+zeebe:
+  client:
+    worker:
+      defaultName: "default"


### PR DESCRIPTION
It appears that the default worker name needs to be configured, otherwise using it leads to a NPE.