### PR TITLE
feat: support PATCH /jobs/{key} to throw an error

### DIFF
--- a/src/test/kotlin/com/github/korthout/zeeberestclient/JobControllerTests.kt
+++ b/src/test/kotlin/com/github/korthout/zeeberestclient/JobControllerTests.kt
@@ -348,10 +348,68 @@ class JobControllerTests(@Autowired val mvc: MockMvc) {
             """))
   }
 
+  @Test
+  fun putStatusShouldAcceptErrorThrown() {
+    mvc
+      .perform(
+        patch("/jobs/1")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+               {
+                 "status": "error_thrown",
+                 "errorCode": "123"
+               }
+               """))
+      .andExpect(status().isNoContent)
+  }
+
+  @Test
+  fun putStatusShouldAcceptErrorThrownWithErrorMessage() {
+    mvc
+      .perform(
+        patch("/jobs/1")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+               {
+                 "status": "error_thrown",
+                 "errorCode": "123",
+                 "errorMessage": "I failed"
+               }
+               """))
+      .andExpect(status().isNoContent)
+  }
+
+  @Test
+  fun putStatusShouldRejectErrorThrownWithoutErrorCode() {
+    mvc
+      .perform(
+        patch("/jobs/1")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+               {
+                 "status": "error_thrown"
+               }
+               """))
+      .andExpect(status().isBadRequest)
+      .andExpect(content().json("""{ "data": null}"""))
+      .andExpect(
+        content()
+          .json(
+            """
+            {
+              "error": "Expected body property `errorCode` to be provided, but it's null or undefined."
+            }
+            """))
+  }
+
   val fakeActivatedJobs: List<ActivatedJob> = listOf(FakeActivatedJob)
   val emptyActivatedJobs: List<ActivatedJob> = emptyList()
   val fakeCompletedJob = object : CompleteJobResponse {}
   val fakeFailedJob = object : FailJobResponse {}
+  val throwError = null
 
   object FakeActivatedJob : ActivatedJob {
     override fun getKey(): Long {

--- a/src/test/kotlin/com/github/korthout/zeeberestclient/zeebe/CompletedZeebeFuture.kt
+++ b/src/test/kotlin/com/github/korthout/zeeberestclient/zeebe/CompletedZeebeFuture.kt
@@ -12,16 +12,15 @@ class CompletedZeebeFuture<T>(private val value: T? = null, private val error: T
   ZeebeFuture<T>, CompletableFuture<T>() {
 
   init {
-    if (value != null) {
-      complete(value)
-    } else {
+    if (error != null) {
       completeExceptionally(error)
+    } else if (value == null) {
+      complete(null)
+    } else {
+      complete(value)
     }
   }
 
-  override fun complete(value: T): Boolean {
-    return super.complete(value)
-  }
   override fun join(timeout: Long, unit: TimeUnit?): T {
     if (value != null) {
       return value

--- a/src/test/kotlin/com/github/korthout/zeeberestclient/zeebe/FakeZeebeClientLifecycle.kt
+++ b/src/test/kotlin/com/github/korthout/zeeberestclient/zeebe/FakeZeebeClientLifecycle.kt
@@ -62,6 +62,10 @@ class FakeZeebeClientLifecycle :
     FakeZeebeClient.onFailJobsCommand(error)
   }
 
+  fun onThrowErrorCommand(error: Throwable) {
+    FakeZeebeClient.onThrowErrorCommand(error)
+  }
+
   fun isRunning(value: Boolean) {
     this.running = value
   }


### PR DESCRIPTION
Adds the endpoint to PATCH /jobs/{key}, which can be used to throw an error.

closes #24 