### PR TITLE
feat: publish message

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Camunda Platform REST API aims to provide a simple but flexible REST API, to
 | `POST`  | `/process-instances` | Create a new Process Instance            |
 | `GET`   | `/jobs`              | Activate Jobs                            |
 | `PATCH` | `/jobs/{key}`        | Update a Job                             |
+| `POST`  | `/messages`          | Publish a Message                        |
 | ..      | ..                   | Not yet implemented                      |
 
 You can find the full API reference documentation under [`docs/api.md`](docs/api.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,7 @@ This document tries to provide full reference documentation on the REST API.
 | `POST`  | `/process-instances` | Create a new Process Instance            |
 | `GET`   | `/jobs`              | Activate Jobs                            |
 | `PATCH` | `/jobs/{key}`        | Update a Job                             |
+| `POST`  | `/messages`          | Publish a Message                        |
 | ..      | ..                   | Not yet implemented                      |
 
 ## `GET /status`
@@ -176,6 +177,54 @@ On HttpStatus `400`, `503`:
 ```json5
 {
   "data": null,
+  "error": "string"
+}
+```
+
+## `POST /messages`
+
+Publish a message.
+
+Can be used to:
+- Correlate a message to a message start event, and start a new process instance.
+- Correlate a message to a message boundary event, or an Event SubProcess message start event, and continue the execution of a process instance.
+
+**Required:**
+- body containing:
+
+```json5
+{
+  // required
+  "name": "string",
+  
+  // optional
+  "correlationKey": "string",
+
+  // optional
+  "messageId": "string",
+
+  // optional
+  "timeToLive": "string",
+
+  // optional
+  "variables": "object or null"
+}
+```
+
+On HttpStatus `200`:
+
+```json5
+{
+  "key": "number",
+  "error": null
+}
+```
+
+On HttpStatus `400`, `503`:
+
+```json5
+{
+  "key": null,
   "error": "string"
 }
 ```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -93,7 +93,6 @@ paths:
                 $ref: '#/components/schemas/ActivatedJobsResponse'
         '503':
           description: Unable to connect to Zeebe cluster
-
   /jobs/{key}:
     patch:
       summary: Update a Job
@@ -138,6 +137,22 @@ paths:
                 $ref: '#/components/schemas/UpdateJobResponse'
         '503':
           description: Unable to connect to Zeebe cluster
+  /messages:
+    post:
+      summary: Publish a single message
+      description: ''
+      operationId: publishMessage
+      responses:
+        '200':
+          description: successfully published
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublishMessageResponse'
+        '503':
+          description: Unable to connect to Zeebe cluster
+      requestBody:
+        $ref: '#/components/requestBodies/PublishMessageRequest'
 
 components:
   requestBodies:
@@ -154,6 +169,13 @@ components:
           schema:
             $ref: '#/components/schemas/UpdateJobRequest'
       description: A request to update a job
+      required: true
+    PublishMessageRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PublishMessageRequest'
+      description: A request to publish a new message for correlation
       required: true
 
   schemas:
@@ -321,6 +343,39 @@ components:
         data: {}
         error:
           type: string
+    PublishMessageResponse:
+      title: A response to PublishMessageRequest
+      description: A response to PublishMessageRequest
+      type: object
+      properties:
+        key:
+          type: integer
+          format: int64
+          description: The unique ID of the message that was published
+        error:
+          type: string
+    PublishMessageRequest:
+      title: A request to publish a new message
+      description: A request to publish a new message
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the message
+        correlationKey:
+          type: string
+          description: The correlation key of the message
+          default: ""
+        messageId:
+          type: string
+          description: The unique ID of the message. Only useful to ensure only one message with the given ID will ever be published (during its lifetime)
+          default: ""
+        timeToLive:
+          type: string
+          description: Define how long the message should be buffered on the broker, in milliseconds
+          default: "0ms"
+        variables:
+          description: The message variables as a JSON document
 
   examples:
     durationTenSeconds:

--- a/src/main/kotlin/com/github/korthout/camundarestapi/MessageController.kt
+++ b/src/main/kotlin/com/github/korthout/camundarestapi/MessageController.kt
@@ -1,0 +1,50 @@
+package com.github.korthout.camundarestapi
+
+import com.blueanvil.toDuration
+import com.github.korthout.camundarestapi.apis.MessagesApi
+import com.github.korthout.camundarestapi.models.PublishMessageRequest
+import com.github.korthout.camundarestapi.models.PublishMessageResponse
+import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientLifecycle
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MessageController : MessagesApi {
+
+  @Autowired lateinit var client: ZeebeClientLifecycle
+
+  override fun publishMessage(
+    publishMessageRequest: PublishMessageRequest
+  ): ResponseEntity<PublishMessageResponse> =
+    when {
+      !client.isRunning ->
+        ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+          .body(
+            PublishMessageResponse(
+              error =
+                "Unable to connect to Zeebe cluster." +
+                  " Please try again, or check the configuration settings."))
+      publishMessageRequest.name != null ->
+        client
+          .newPublishMessageCommand()
+          .messageName(publishMessageRequest.name)
+          .correlationKey(publishMessageRequest.correlationKey)
+          .messageId(publishMessageRequest.messageId)
+          .timeToLive(publishMessageRequest.timeToLive?.toDuration())
+          .variables(publishMessageRequest.variables)
+          .send()
+          .thenApply { ResponseEntity.ok(PublishMessageResponse(key = it.messageKey)) }
+          .exceptionally {
+            ResponseEntity.badRequest().body(PublishMessageResponse(error = it.cause.toString()))
+          }
+          .toCompletableFuture()
+          .join()
+      else ->
+        ResponseEntity.badRequest()
+          .body(
+            PublishMessageResponse(
+              error = "Expected body property `name` to be provided, but it's null or undefined."))
+    }
+}

--- a/src/test/kotlin/com/github/korthout/camundarestapi/MessageControllerTests.kt
+++ b/src/test/kotlin/com/github/korthout/camundarestapi/MessageControllerTests.kt
@@ -1,0 +1,189 @@
+package com.github.korthout.camundarestapi
+
+import com.github.korthout.camundarestapi.zeebe.FakeZeebeClientLifecycle
+import io.camunda.zeebe.client.api.response.PublishMessageResponse
+import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientLifecycle
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MessageControllerTests(@Autowired val mvc: MockMvc) {
+
+  @TestConfiguration
+  internal class ControllerTestConfiguration {
+    @Bean
+    fun client(): ZeebeClientLifecycle {
+      return FakeZeebeClientLifecycle()
+    }
+  }
+
+  @Autowired lateinit var zeebeClient: FakeZeebeClientLifecycle
+
+  @BeforeEach
+  fun setup() {
+    zeebeClient.reset()
+  }
+
+  @Test
+  fun postShouldPublishMessageWithName() {
+    zeebeClient.onPublishMessageCommand(FakePublishMessageRequest)
+    mvc
+      .perform(
+        post("/messages")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+              {
+                "name": "testMessageName"
+              }  
+              """))
+      .andExpect(status().isOk)
+      .andExpect(content().json("""{ "error":  null}"""))
+      .andExpect(content().json("""{ "key": 1 }"""))
+  }
+
+  @Test
+  fun postShouldPublishMessageWithCorrelationKey() {
+    zeebeClient.onPublishMessageCommand(FakePublishMessageRequest)
+    mvc
+      .perform(
+        post("/messages")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+              {
+                "name": "testMessageName",
+                "correlationKey": "testCorrelationKey"
+              }  
+              """))
+      .andExpect(status().isOk)
+      .andExpect(content().json("""{ "error":  null}"""))
+      .andExpect(content().json("""{ "key": 1 }"""))
+  }
+
+  @Test
+  fun postShouldPublishMessageWithTimeToLive() {
+    zeebeClient.onPublishMessageCommand(FakePublishMessageRequest)
+    mvc
+      .perform(
+        post("/messages")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+              {
+                "name": "testMessageName",
+                "correlationKey": "testCorrelationKey",
+                "timeToLive": "1s"
+              }  
+              """))
+      .andExpect(status().isOk)
+      .andExpect(content().json("""{ "error":  null}"""))
+      .andExpect(content().json("""{ "key": 1 }"""))
+  }
+
+  @Test
+  fun postShouldPublishMessageWithMessageId() {
+    zeebeClient.onPublishMessageCommand(FakePublishMessageRequest)
+    mvc
+      .perform(
+        post("/messages")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+              {
+                "name": "testMessageName",
+                "correlationKey": "testCorrelationKey",
+                "timeToLive": "1s",
+                "messageId": "testMessageId"
+              }  
+              """))
+      .andExpect(status().isOk)
+      .andExpect(content().json("""{ "error":  null}"""))
+      .andExpect(content().json("""{ "key": 1 }"""))
+  }
+
+  @Test
+  fun postShouldPublishMessageWithVariables() {
+    zeebeClient.onPublishMessageCommand(FakePublishMessageRequest)
+    mvc
+      .perform(
+        post("/messages")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+              {
+                "name": "testMessageName",
+                "correlationKey": "testCorrelationKey",
+                "timeToLive": "1s",
+                "messageId": "testMessageId",
+                "variables": {
+                    "foo": "bar"
+                  }
+              }  
+              """))
+      .andExpect(status().isOk)
+      .andExpect(content().json("""{ "error":  null}"""))
+      .andExpect(content().json("""{ "key": 1 }"""))
+  }
+
+  @Test
+  fun postShouldRejectMessageWithoutName() {
+    mvc
+      .perform(
+        post("/messages")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+              {
+                "correlationKey": "testMessageKey"
+              }  
+              """))
+      .andExpect(status().isBadRequest)
+      .andExpect(
+        content()
+          .json(
+            """{ "error":  "Expected body property `name` to be provided, but it's null or undefined."}"""))
+  }
+
+  @Test
+  fun postShouldRespondUnavailable() {
+    zeebeClient.isRunning(false)
+    mvc
+      .perform(
+        post("/messages")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            """
+              {
+                "name": "testMessageName"
+              }  
+              """))
+      .andExpect(status().isServiceUnavailable)
+      .andExpect(content().json("""{ "key": null }"""))
+      .andExpect(
+        content()
+          .json(
+            """
+            {
+              "error": "Unable to connect to Zeebe cluster. Please try again, or check the configuration settings."
+            }
+            """))
+  }
+
+  object FakePublishMessageRequest : PublishMessageResponse {
+    override fun getMessageKey(): Long {
+      return 1L
+    }
+  }
+}

--- a/src/test/kotlin/com/github/korthout/camundarestapi/zeebe/FakeZeebeClientLifecycle.kt
+++ b/src/test/kotlin/com/github/korthout/camundarestapi/zeebe/FakeZeebeClientLifecycle.kt
@@ -4,6 +4,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob
 import io.camunda.zeebe.client.api.response.CompleteJobResponse
 import io.camunda.zeebe.client.api.response.FailJobResponse
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent
+import io.camunda.zeebe.client.api.response.PublishMessageResponse
 import io.camunda.zeebe.client.api.response.Topology
 import io.camunda.zeebe.spring.client.annotation.processor.ZeebeAnnotationProcessorRegistry
 import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientLifecycle
@@ -68,5 +69,13 @@ class FakeZeebeClientLifecycle :
 
   fun isRunning(value: Boolean) {
     this.running = value
+  }
+
+  fun onPublishMessageCommand(message: PublishMessageResponse) {
+    FakeZeebeClient.onPublishMessageCommand(message)
+  }
+
+  fun onPublishMessageCommand(error: Throwable) {
+    FakeZeebeClient.onPublishMessageCommand(error)
   }
 }


### PR DESCRIPTION
* Adds new, Message-related entries to the OpenAPI spec.
* Adds a new MessageController to enable the /messages endpoint.
* Adds test coverage for the new /messages endpoint.

closes #23 