### PR TITLE
ci(release): use add-and-commit action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,13 @@ jobs:
         working-directory: docs
 
       - name: Commit new release version
-        run: echo "dist:\ ${{ inputs.releaseVersion }}" | git commit -F- --no-edit
+        uses: EndBug/add-and-commit@v9
+        with:
+          commit: --signoff
+          default_author: github_actions
+          fetch: false
+          message: 'dist:\ {{ inputs.releaseVersion }}'
+          push: ${{ inputs.dryRun == false }}
 
       - name: Print new release version commit
         run: git show head | cat
@@ -73,7 +79,13 @@ jobs:
           set: ${{ inputs.nextDevelopmentVersion }}
 
       - name: Commit next development version
-        run: echo "dist:\ ${{ inputs.nextDevelopmentVersion }}" | git commit -F- --no-edit
+        uses: EndBug/add-and-commit@v9
+        with:
+          commit: --signoff
+          default_author: github_actions
+          fetch: false
+          message: 'dist:\ {{ inputs.nextDevelopmentVersion }}'
+          push: ${{ inputs.dryRun == false }}
 
       - name: Print next development version commit
         run: git show head | cat


### PR DESCRIPTION
I had forgotten to set the author and email configs to commit, and also hadn't staged the changes for committing yet. This action takes care of it all.