### PR TITLE
Contributing and feedback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,30 @@
 # Contributing to Camunda Platform REST API
 
-## Build from source
+This project is community maintained.
+We welcome contributions for feature requests and bug reports, as well as for docs and code changes.
+
+## Feature requests and bug reports
+
+If you would want to see something added or changed, or encountered a bug.
+Please open an [issue on GitHub](https://github.com/korthout/camunda-platform-rest-api/issues).
+
+## Docs changes
+
+Saw a typo or want to make other changes to the [Docs](https://korthout.github.io/camunda-platform-rest-api/)?
+Please have a look at the documentation's [README](https://github.com/korthout/camunda-platform-rest-api/blob/main/docs/README.md).
+
+If your changes affect the [API](https://korthout.github.io/camunda-platform-rest-api/docs/api) section,
+then you'll need to make the changes to the `openapi.yaml` file,
+and [regenerate the Docs](https://github.com/korthout/camunda-platform-rest-api/blob/main/docs/README.md#update-the-openapi-docs).
+Making changes manually to the [`docs/docs/api`](https://github.com/korthout/camunda-platform-rest-api/tree/main/docs/docs/api)
+is not supported, since those files are generated from the OpenAPI specification.
+
+## Code changes
+
+We also welcome code changes. If you're thinking of opening a large pull request,
+please consider opening an issue on GitHub first to discuss it.
+
+### Build from source
 
 This is a maven project.
 To build it from source, run the command: `mvn clean install -DskipTests` in the root folder.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -184,7 +184,7 @@ const config = {
     announcementBar: {
       id: "announcementBar_1", // Increment on change
       content:
-        `📢 <strong>Public Beta</strong>: We want your <a href="https://github.com/korthout/camunda-platform-rest-api/issues">feedback</a>! 📢
+        `📢 <strong>Public Beta</strong>: We want your <a href="https://forum.camunda.io/t/camunda-platform-rest-api-a-rest-api-for-camunda-platform-8/42610">feedback</a>! 📢
         &nbsp;&nbsp;&nbsp;
         🚧 <strong>Warning:</strong> This API is not yet stable - we might break backward compatibility in newer releases of <code>v0</code>. 🚧`,
     },


### PR DESCRIPTION
Expands the contributing guide with instructions how you can contribute.

This also changes the Documentation's announcements-bar's feedback link to the forum post. This should help explain a bit better how we're looking for feedback.