### PR TITLE
Enable dependabot for the docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,15 @@ updates:
       prefix: "deps(.github): "
     labels:
       - "dependencies"
+
+  # Enable version updates for the docs
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+      time: "13:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps(docs): "
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This enables @dependabot for the docs.

Note that the [package-manager](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) for yarn is `npm`.